### PR TITLE
Backport StrEnum from Python 3.11

### DIFF
--- a/check_all.sh
+++ b/check_all.sh
@@ -3,6 +3,7 @@
 echo "Begin check..." \
 && black . \
 && python -m pytest -vv tests/ \
+&& darglint --docstring-style sphinx -v 2 -z long ranzen \
 && pyright ranzen \
 && pyright tests \
 && echo "Check all complete!"

--- a/ranzen/misc.py
+++ b/ranzen/misc.py
@@ -3,7 +3,7 @@ import copy
 from enum import Enum
 from typing import Any, MutableMapping, TypeVar, overload
 
-__all__ = ["flatten_dict", "gcopy", "str_to_enum"]
+__all__ = ["StrEnum", "flatten_dict", "gcopy", "str_to_enum"]
 
 
 def flatten_dict(
@@ -98,3 +98,52 @@ def str_to_enum(str_: str | E, *, enum: type[E]) -> E:
         raise TypeError(
             f"'{str_}' is not a valid option for enum '{enum.__name__}'; must be one of {valid_ls}."
         )
+
+
+try:
+    # will be available in python 3.11
+    from enum import StrEnum  # type: ignore
+except ImportError:
+    #
+    # the following is copied straight from https://github.com/python/cpython/blob/3.11/Lib/enum.py
+    #
+    # DO NOT CHANGE THIS CODE!
+    #
+    from enum import Enum
+
+    class ReprEnum(Enum):
+        """
+        Only changes the repr(), leaving str() and format() to the mixed-in type.
+        """
+
+    class StrEnum(str, ReprEnum):
+        """
+        Enum where members are also (and must be) strings
+        """
+
+        def __new__(cls, *values):
+            "values must already be of type `str`"
+            if len(values) > 3:
+                raise TypeError("too many arguments for str(): %r" % (values,))
+            if len(values) == 1:
+                # it must be a string
+                if not isinstance(values[0], str):
+                    raise TypeError("%r is not a string" % (values[0],))
+            if len(values) >= 2:
+                # check that encoding argument is a string
+                if not isinstance(values[1], str):
+                    raise TypeError("encoding must be a string, not %r" % (values[1],))
+            if len(values) == 3:
+                # check that errors argument is a string
+                if not isinstance(values[2], str):
+                    raise TypeError("errors must be a string, not %r" % (values[2]))
+            value = str(*values)
+            member = str.__new__(cls, value)
+            member._value_ = value
+            return member
+
+        def _generate_next_value_(name: str, start: int, count: int, last_values: list[Any]):
+            """
+            Return the lower-cased version of the member name.
+            """
+            return name.lower()

--- a/tests/misc_test.py
+++ b/tests/misc_test.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from enum import auto
 
-from ranzen import flatten_dict, gcopy
+from ranzen import StrEnum, flatten_dict, gcopy
 
 
 def test_flatten_dict() -> None:
@@ -31,3 +32,16 @@ def test_gcopy() -> None:
     for obj in obj_dcps:
         assert obj.value != obj_scp.value
         assert obj.ls[0] != obj_scp.ls[0]
+
+
+def test_strenum() -> None:
+    class _Things(StrEnum):
+        POTATO = auto()
+        ORANGE = auto()
+        SPADE = auto()
+
+    for thing in _Things:
+        assert thing.value == thing.name.lower()
+
+        assert f"{thing}" == thing.name.lower()
+        assert f"{thing!r}" == f"<_Things.{thing.name}: '{thing.value}'>"


### PR DESCRIPTION
https://docs.python.org/3.11/library/enum.html#enum.StrEnum

To be used instead of `@enum_name_str`.  It serves similar purposes.