### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,4 @@ updates:
     # Check the pypi registry for updates every week
     schedule:
       interval: "weekly"
+    versioning-strategy: lockfile-only


### PR DESCRIPTION
Updates must comply with lockfile specification.
> Only create pull requests to update lockfiles. Ignore any new versions that would require package manifest changes.