### PR TITLE
Fix the example sections in the documentation by indenting their content

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classes = ["MISSING"]
 
 [tool.poetry]
 name = "ranzen"
-version = "1.0.0.dev0"
+version = "3.0.0.dev0"
 description = "A toolkit facilitating machine-learning experimentation."
 authors = ["PAL <info@predictive-analytics-lab.com>"]
 license = "Apache License 2.0"

--- a/ranzen/hydra/relay.py
+++ b/ranzen/hydra/relay.py
@@ -126,12 +126,11 @@ class Relay:
     the subclasses will be instantiated and the run method called on the raw config.
 
     :example:
-
-    >>> Relay.with_hydra(
-    >>>     root="conf",
-    >>>     model=[Option(MoCoV2), DINO],
-    >>>     datamodule=[Option(ColoredMNISTDataModule, "cmnist")],
-    >>> )
+        >>> Relay.with_hydra(
+        >>>     root="conf",
+        >>>     model=[Option(MoCoV2), DINO],
+        >>>     datamodule=[Option(ColoredMNISTDataModule, "cmnist")],
+        >>> )
 
     """
 

--- a/ranzen/hydra/utils.py
+++ b/ranzen/hydra/utils.py
@@ -59,14 +59,13 @@ class SchemaRegistration:
     """Register hydra schemas.
 
     :example:
-
-    >>> sr = SchemaRegistration()
-    >>> sr.register(Config, path="experiment_schema")
-    >>> sr.register(TrainerConf, path="trainer/trainer_schema")
-    >>>
-    >>> with sr.new_group("schema/data", target_path="data") as group:
-    >>>    group.add_option(CelebaDataConf, name="celeba")
-    >>>    group.add_option(WaterbirdsDataConf, name="waterbirds")
+        >>> sr = SchemaRegistration()
+        >>> sr.register(Config, path="experiment_schema")
+        >>> sr.register(TrainerConf, path="trainer/trainer_schema")
+        >>>
+        >>> with sr.new_group("schema/data", target_path="data") as group:
+        >>>    group.add_option(CelebaDataConf, name="celeba")
+        >>>    group.add_option(WaterbirdsDataConf, name="waterbirds")
     """
 
     def __init__(self) -> None:

--- a/ranzen/misc.py
+++ b/ranzen/misc.py
@@ -180,18 +180,17 @@ class AddDict(Dict[_KT, _VT], Addable):
     key-wise addition.
 
     :example:
+        .. code-block:: python
 
-    .. code-block:: python
+            # Simple case of addition of integers.
+            d1 = AddDict({"foo": 1, "bar": 2})
+            d2 = {"foo": 3, "bar": 4}
+            d1 + d2 # {'foo': 4, 'bar': 6}
 
-        # Simple case of addition of integers.
-        d1 = AddDict({"foo": 1, "bar": 2})
-        d2 = {"foo": 3, "bar": 4}
-        d1 + d2 # {'foo': 4, 'bar': 6}
-
-        # Concatenation of lists
-        d3 = AddDict({"foo": [1], "bar": [2]})
-        d4 = {"foo": [3, 4], "bar": 4}
-        d3 + d4 # {'foo': [1, 3, 4], 'bar': [2, 4]}
+            # Concatenation of lists
+            d3 = AddDict({"foo": [1], "bar": [2]})
+            d4 = {"foo": [3, 4], "bar": 4}
+            d3 + d4 # {'foo': [1, 3, 4], 'bar': [2, 4]}
     """
 
     @overload

--- a/ranzen/torch/data.py
+++ b/ranzen/torch/data.py
@@ -280,12 +280,11 @@ class SequentialBatchSampler(BatchSamplerBase):
     :param generator: Pseudo-random-number generator to use for shuffling the dataset.
 
     :example:
-
-    >>> batch_sampler = InfSequentialBatchSampler(data_source=train_data, batch_size=100, shuffle=True)
-    >>> train_loader = DataLoader(train_data, batch_sampler=batch_sampler, shuffle=False, drop_last=False) # drop_last and shuffle need to be False
-    >>> train_loader_iter = iter(train_loader)
-    >>> for _ in range(train_iters):
-    >>>     batch = next(train_loader_iter)
+        >>> batch_sampler = InfSequentialBatchSampler(data_source=train_data, batch_size=100, shuffle=True)
+        >>> train_loader = DataLoader(train_data, batch_sampler=batch_sampler, shuffle=False, drop_last=False) # drop_last and shuffle need to be False
+        >>> train_loader_iter = iter(train_loader)
+        >>> for _ in range(train_iters):
+        >>>     batch = next(train_loader_iter)
     """
 
     def __init__(
@@ -387,13 +386,12 @@ class StratifiedBatchSampler(BatchSamplerBase):
     :param generator: Pseudo-random-number generator to use for shuffling the dataset.
 
     :example:
-
-    >>> list(StratifiedSampler([0, 0, 0, 0, 1, 1, 2], 10, replacement=True))
-    [3, 5, 6, 3, 5, 6, 0, 5, 6]
-    >>> list(StratifiedSampler([0, 0, 0, 0, 1, 1, 2], 10, replacement=True, multiplier={2: 2}))
-    [3, 4, 6, 6, 3, 5, 6, 6, 1, 5, 6, 6]
-    >>> list(StratifiedSampler([0, 0, 0, 0, 1, 1, 1, 2, 2], 7, replacement=False))
-    [2, 6, 7, 0, 5, 8]
+        >>> list(StratifiedSampler([0, 0, 0, 0, 1, 1, 2], 10, replacement=True))
+        [3, 5, 6, 3, 5, 6, 0, 5, 6]
+        >>> list(StratifiedSampler([0, 0, 0, 0, 1, 1, 2], 10, replacement=True, multiplier={2: 2}))
+        [3, 4, 6, 6, 3, 5, 6, 6, 1, 5, 6, 6]
+        >>> list(StratifiedSampler([0, 0, 0, 0, 1, 1, 1, 2, 2], 7, replacement=False))
+        [2, 6, 7, 0, 5, 8]
     """
 
     def __init__(

--- a/ranzen/torch/loss.py
+++ b/ranzen/torch/loss.py
@@ -82,18 +82,17 @@ def cross_entropy_loss(
     :returns: The (reduced) cross-entropy between ``input`` and ``target``.
 
     :example:
-
-    >>> # Example of target with class indices
-    >>> input = torch.randn(3, 5, requires_grad=True)
-    >>> target = torch.randint(5, (3,), dtype=torch.int64)
-    >>> loss = F.cross_entropy(input, target)
-    >>> loss.backward()
-    >>>
-    >>> # Example of target with class probabilities
-    >>> input = torch.randn(3, 5, requires_grad=True)
-    >>> target = torch.randn(3, 5).softmax(dim=1)
-    >>> loss = F.cross_entropy(input, target)
-    >>> loss.backward()
+        >>> # Example of target with class indices
+        >>> input = torch.randn(3, 5, requires_grad=True)
+        >>> target = torch.randint(5, (3,), dtype=torch.int64)
+        >>> loss = F.cross_entropy(input, target)
+        >>> loss.backward()
+        >>>
+        >>> # Example of target with class probabilities
+        >>> input = torch.randn(3, 5, requires_grad=True)
+        >>> target = torch.randn(3, 5).softmax(dim=1)
+        >>> loss = F.cross_entropy(input, target)
+        >>> loss.backward()
     """
     if isinstance(reduction, str):
         reduction = str_to_enum(str_=reduction, enum=ReductionType)
@@ -213,19 +212,18 @@ class CrossEntropyLoss(nn.Module):
             Computer Vision <https://arxiv.org/abs/1512.00567>`__. Default: :math:`0.0`.
 
         :example:
-
-        >>> # Example of target with class indices
-        >>> loss = CrossEntropyLoss()
-        >>> input = torch.randn(3, 5, requires_grad=True)
-        >>> target = torch.empty(3, dtype=torch.long).random_(5)
-        >>> output = loss(input, target)
-        >>> output.backward()
-        >>>
-        >>> # Example of target with class probabilities
-        >>> input = torch.randn(3, 5, requires_grad=True)
-        >>> target = torch.randn(3, 5).softmax(dim=1)
-        >>> output = loss(input, target)
-        >>> output.backward()
+            >>> # Example of target with class indices
+            >>> loss = CrossEntropyLoss()
+            >>> input = torch.randn(3, 5, requires_grad=True)
+            >>> target = torch.empty(3, dtype=torch.long).random_(5)
+            >>> output = loss(input, target)
+            >>> output.backward()
+            >>>
+            >>> # Example of target with class probabilities
+            >>> input = torch.randn(3, 5, requires_grad=True)
+            >>> target = torch.randn(3, 5).softmax(dim=1)
+            >>> output = loss(input, target)
+            >>> output.backward()
         """
         super().__init__()
         if isinstance(reduction, str):

--- a/ranzen/torch/optimizers/sam.py
+++ b/ranzen/torch/optimizers/sam.py
@@ -41,23 +41,22 @@ class SAM(Optimizer):
         :raises ValueError: if ``rho`` is negative.
 
         :example:
+            .. code-block:: python
 
-        .. code-block:: python
+                # Use AdamW as the base optimizer.
+                base_optimizer = AdamW(model.parameters())
+                # Wrap the base optimizer in SAM.
+                optimizer = SAM(base_optimizer)
 
-            # Use AdamW as the base optimizer.
-            base_optimizer = AdamW(model.parameters())
-            # Wrap the base optimizer in SAM.
-            optimizer = SAM(base_optimizer)
+                # Closure required for recomputing the loss after computing epsilon(w).
+                def _closure():
+                  return loss_function(logits=model(input), targets=targets)
 
-            # Closure required for recomputing the loss after computing epsilon(w).
-            def _closure():
-              return loss_function(logits=model(input), targets=targets)
+                loss = _closure()
+                loss.backward()
 
-            loss = _closure()
-            loss.backward()
-
-            optimizer.step(closure=_closure)
-            optimizer.zero_grad()
+                optimizer.step(closure=_closure)
+                optimizer.zero_grad()
         """
         if rho < 0.0:
             raise ValueError(f"Invalid rho value: {rho}. (Should be non-negative)")

--- a/ranzen/torch/transforms/mixup.py
+++ b/ranzen/torch/transforms/mixup.py
@@ -67,9 +67,9 @@ class RandomMixUp(Generic[LS]):
 
         :param mode: Which mode to use to mix up samples: geometric or linear.
 
-        .. note::
-            The (weighted) geometric mean, enabled by ``mode=geometric``, is only valid for positive
-            inputs.
+            .. note::
+                The (weighted) geometric mean, enabled by ``mode=geometric``, is only valid for
+                positive inputs.
 
         :param p: The probability with which the transform will be applied to a given sample.
         :param num_classes: The total number of classes in the dataset that needs to be specified if
@@ -78,9 +78,9 @@ class RandomMixUp(Generic[LS]):
 
         :param featurewise: Whether to sample sample feature-wise instead of sample-wise.
 
-        .. note::
-            If the ``lambda_sampler`` is a BernoulliDistribution, then featurewise sampling will
-            always be enabled.
+            .. note::
+                If the ``lambda_sampler`` is a BernoulliDistribution, then featurewise sampling will
+                always be enabled.
 
         :param inplace: Whether the transform should be performed in-place.
 
@@ -121,9 +121,9 @@ class RandomMixUp(Generic[LS]):
 
         :param mode: Which mode to use to mix up samples: geometric or linear.
 
-        .. note::
-            The (weighted) geometric mean, enabled by ``mode=geometric``, is only valid for positive
-            inputs.
+            .. note::
+                The (weighted) geometric mean, enabled by ``mode=geometric``, is only valid for
+                positive inputs.
 
         :param p: The probability with which the transform will be applied to a given sample.
         :param num_classes: The total number of classes in the dataset that needs to be specified if
@@ -164,9 +164,9 @@ class RandomMixUp(Generic[LS]):
         :param high: Upper range (inclusive).
         :param mode: Which mode to use to mix up samples: geometric or linear.
 
-        .. note::
-            The (weighted) geometric mean, enabled by ``mode=geometric``, is only valid for positive
-            inputs.
+            .. note::
+                The (weighted) geometric mean, enabled by ``mode=geometric``, is only valid for
+                positive inputs.
 
         :param p: The probability with which the transform will be applied to a given sample.
         :param num_classes: The total number of classes in the dataset that needs to be specified if

--- a/ranzen/torch/utils.py
+++ b/ranzen/torch/utils.py
@@ -54,11 +54,10 @@ class Event:
     """Emulates torch.cuda.Event, but supports running on a CPU too.
 
     :example:
-
-    >>> from ranzen.torch import Event
-    >>> with Event() as event:
-    >>>     y = some_nn_module(x)
-    >>> print(event.time)
+        >>> from ranzen.torch import Event
+        >>> with Event() as event:
+        >>>     y = some_nn_module(x)
+        >>> print(event.time)
     """
 
     def __init__(self):


### PR DESCRIPTION
It turns out you have to indent everything inside the example, otherwise sphinx doesn't treat it as belonging to the example.