### PR TITLE
Resolve all the interpolations in the config dict because that's nicer for logging

### DIFF
--- a/ranzen/hydra/relay.py
+++ b/ranzen/hydra/relay.py
@@ -390,9 +390,7 @@ class Relay:
             relay: cls = instantiate(cfg, _recursive_=instantiate_recursively)
             config_dict = cast(
                 Dict[str, Any],
-                OmegaConf.to_container(
-                    cfg, throw_on_missing=True, enum_to_str=False, resolve=True
-                ),
+                OmegaConf.to_container(cfg, throw_on_missing=True, enum_to_str=False, resolve=True),
             )
             return relay.run(config_dict)
 

--- a/ranzen/hydra/relay.py
+++ b/ranzen/hydra/relay.py
@@ -390,7 +390,9 @@ class Relay:
             relay: cls = instantiate(cfg, _recursive_=instantiate_recursively)
             config_dict = cast(
                 Dict[str, Any],
-                OmegaConf.to_container(cfg, throw_on_missing=True, enum_to_str=False),
+                OmegaConf.to_container(
+                    cfg, throw_on_missing=True, enum_to_str=False, resolve=True
+                ),
             )
             return relay.run(config_dict)
 


### PR DESCRIPTION
Currently, it's logged like this, which isn't very nice:
![image](https://user-images.githubusercontent.com/7741417/195719958-98da80ce-115f-4c6b-b950-0d8c9c8182ce.png)
