### PR TITLE
Fix new pyright error

### DIFF
--- a/tests/relay_test.py
+++ b/tests/relay_test.py
@@ -41,6 +41,7 @@ class DummyRelay(Relay):
         instantiate_recursively: bool = True,
         attr1: Options[DummyOption],
         attr2: Options[DummyOption],
+        **options: Option,
     ) -> None:
         super().with_hydra(
             root=root,


### PR DESCRIPTION
Recent update of pyright is stricter for method overrides.